### PR TITLE
Updated status parameter on parsed response, fixes #17

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -49,11 +49,10 @@ function isConfigured() {
  * @return {object} An object with the keys: body, raw, status
  */
 function parseResponse(data) {
-    console.log(data);
     let response = {
         body: {},
         raw: data,
-        status: data.status
+        status: data.statusCode
     };
 
     if (!data.body) {


### PR DESCRIPTION
Updated `status` to `statusCode`. the function was mapping an inexistent object key. 

Also a `console.log` outputting the raw response was removed.
